### PR TITLE
Bump the Android native library in order to fix a crash with certain PDFs

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.vscode
 demo/
 screenshots/
 *.gif

--- a/pdf-view.android.ts
+++ b/pdf-view.android.ts
@@ -30,7 +30,7 @@ export class PDFView extends PDFViewCommon {
 
   public createNativeView() {
     // tslint:disable-next-line:no-unsafe-any
-    return new pdfviewer.PDFView(this._context);
+    return new pdfviewer.PDFView(this._context, null);
   }
 
   public [srcProperty.setNative](value: string) {

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -1,11 +1,3 @@
-android {
-  productFlavors {
-    "nativescript-pdf-view" {
-      dimension "nativescript-pdf-view"
-    }
-  }
-}
-
 dependencies {
-    compile 'com.github.barteksc:android-pdf-viewer:2.5.1'
+    implementation 'com.github.barteksc:android-pdf-viewer:2.8.2'
 }


### PR DESCRIPTION
Hi!

Long time fan (and user) of your plugin!

Today we found this particular PDF crashes the app when loaded: https://loopmein-dev.imgix.net/vehicle-documents/d21fcae0-85be-4577-8ee5-d5452c9c1255.pdf

The reason is unknown, the only thing we know is it's fixed by bumping the native Android library to the latest version of the 2.x branch. Somewhere in between 2.5.1 and 2.8.2 this crash was fixed by the author.

While I was in the gradle file I also switched `compile` to `implementation`, since that's the recommended way to load libraries in gradle these days.

Also added `.vscode` to `.npmignore` because it has no business in the npm package.

Thanks a lot for considering merging this, and it would be awesome if you can publish a new version to npm as well!